### PR TITLE
ENG-390 Tracking journey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2768,6 +2768,12 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
+    "@types/segment-analytics": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@types/segment-analytics/-/segment-analytics-0.0.34.tgz",
+      "integrity": "sha512-fiOyEgyqJY2Mv9k72WG4XoY4fVE31byiSUrEFcNh+MgHcH3HuJmoz2J7ktO3YizBrN6/RuaH1tY5J/5I5BJHJQ==",
+      "dev": true
+    },
     "@types/source-list-map": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -64,8 +64,9 @@
     "@types/react-dom": "^16.9.8",
     "@types/react-highlight": "^0.12.2",
     "@types/react-router-dom": "^5.1.6",
+    "@types/segment-analytics": "0.0.34",
     "@types/styled-components": "^5.1.10",
-    "prettier": "^2.0.5",
-    "husky": "^7.0.1"
+    "husky": "^7.0.1",
+    "prettier": "^2.0.5"
   }
 }

--- a/src/hooks/useContext.ts
+++ b/src/hooks/useContext.ts
@@ -43,6 +43,11 @@ const _useContext = () => {
 
   const auth = (__userData: User) => {
     setUserData(__userData);
+    analytics.ready(() => {
+      analytics.identify(__userData.id, {
+        ...__userData,
+      } as Object);
+    });
     localStorage.setItem(LS_KEY, JSON.stringify(__userData));
   };
 


### PR DESCRIPTION
This should be enough to track the previous, anonymous journey the users went through before reaching the portal. Segment already uses a cookie that is valid for the naked domain. So, if they were navigating on websites like:
- https://developer.fusebit.io/
- https://fusebit.io/
- https://go.fusebit.io/slack/

We will still be able to link all the journey with Segment.