### PR TITLE
[ENG-675] Expand Installs or Identities row

### DIFF
--- a/src/components/AsyncTags/AsyncTags.tsx
+++ b/src/components/AsyncTags/AsyncTags.tsx
@@ -5,7 +5,10 @@ import * as CSC from '../globalStyle';
 
 interface Props {
   isLoading: boolean;
-  tags: string[];
+  tags: {
+    value: string;
+    onClick?: (id: string) => void;
+  }[];
 }
 
 const AsyncTags: React.FC<Props> = ({ isLoading, tags }) => {
@@ -15,7 +18,9 @@ const AsyncTags: React.FC<Props> = ({ isLoading, tags }) => {
         <CSC.Spinner />
       ) : (
         <List>
-          <Tag>{tags}</Tag>
+          {tags.map((tag) => {
+            return <Tag onClick={() => tag.onClick?.(tag.value)}> {tag.value} </Tag>;
+          })}
         </List>
       )}
     </>

--- a/src/components/BaseTable/Row.tsx
+++ b/src/components/BaseTable/Row.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import * as SC from './styles';
 import { Checkbox, TableCell, Collapse, useMediaQuery } from '@material-ui/core';
 import { BaseTableProps } from './types';
+import { useQuery } from '../../hooks/useQuery';
 
 interface Props {
   row: any;
@@ -15,7 +16,8 @@ interface Props {
 
 const Row = ({ row, onSelectRow, checked, headers, currentMobileRow, collapseTrigger, isCollapsible }: Props) => {
   const isMobile = useMediaQuery('(max-width: 880px)');
-  const [isExpanded, setIsExpanded] = useState(false);
+  const query = useQuery();
+  const [isExpanded, setIsExpanded] = useState(query.get('expanded')?.split(',').includes(row.id) || false);
 
   const renderCollapsable = (row: any) => {
     return (

--- a/src/components/ConnectorDetail/Identities/IdentitiesTable/AssociatedInstalls.tsx
+++ b/src/components/ConnectorDetail/Identities/IdentitiesTable/AssociatedInstalls.tsx
@@ -1,4 +1,6 @@
+import { useHistory } from 'react-router-dom';
 import { useAccountConnectorIdentityInstallsGetAll } from '../../../../hooks/api/v2/account/connector/identity/installs/useGetAll';
+import { useGetRedirectLink } from '../../../../hooks/useGetRedirectLink';
 import AsyncTags from '../../../AsyncTags';
 
 interface Props {
@@ -7,8 +9,19 @@ interface Props {
 
 const AssociatedInstalls = ({ identityId }: Props) => {
   const { isLoading, data } = useAccountConnectorIdentityInstallsGetAll({ identityId }, { enabled: !!identityId });
+  const history = useHistory();
+  const { getRedirectLink } = useGetRedirectLink();
 
-  return <AsyncTags isLoading={isLoading} tags={(data || [])?.map((i) => i.id)} />;
+  return (
+    <AsyncTags
+      isLoading={isLoading}
+      tags={(data || [])?.map((i) => ({
+        value: i.id,
+        onClick: () =>
+          history.push(getRedirectLink(`/integration/${i.tags['fusebit.parentEntityId']}/installs?expanded=${i.id}`)),
+      }))}
+    />
+  );
 };
 
 export default AssociatedInstalls;

--- a/src/components/IntegrationDetail/Installs/InstallsTable/InstallsTable.tsx
+++ b/src/components/IntegrationDetail/Installs/InstallsTable/InstallsTable.tsx
@@ -31,18 +31,18 @@ const InstallsTable = () => {
 
   const { items = [] } = data?.data || {};
 
-  const rows = items.map((identity) => ({
-    installID: identity.id,
-    id: identity.id,
-    dateCreated: format(new Date(identity.dateAdded), 'MM/dd/yyyy'),
+  const rows = items.map((install) => ({
+    installID: install.id,
+    id: install.id,
+    dateCreated: format(new Date(install.dateAdded), 'MM/dd/yyyy'),
     listOfTags: (
       <List>
-        {Object.keys(identity.tags).map((key) => {
-          return <Tag>{key + ': ' + identity.tags[key]}</Tag>;
+        {Object.keys(install.tags).map((key) => {
+          return <Tag>{key + ': ' + install.tags[key]}</Tag>;
         })}
       </List>
     ),
-    collapsableContent: <CodeBlock code={identity} />,
+    collapsableContent: <CodeBlock code={install} />,
   }));
 
   const headers = [

--- a/src/interfaces/install.ts
+++ b/src/interfaces/install.ts
@@ -2,6 +2,7 @@ interface Tags {
   [key: string]: string | undefined;
   'session.master'?: string;
   'fusebit.tenantId'?: string;
+  'fusebit.parentEntityId'?: string;
 }
 
 export interface InstallInstance {


### PR DESCRIPTION
- Add rows from `BaseTable` component automatically expanded by the query param `expanded`.
- Add redirect to the installs table with the install row expanded when user clicks in an associated install tag.