### PR TITLE
Fix style issue with Monaco Editor

### DIFF
--- a/src/components/globalStyle.ts
+++ b/src/components/globalStyle.ts
@@ -21,6 +21,14 @@ export default createGlobalStyle`
         }
     }
 
+    .monaco-editor {
+      a {
+          span {
+              display: initial;
+          }
+      }
+    }
+
     #pendo-text-7f2119cd { // this is pendo launch guide, for some reason it doesnt have cursor pointer by default ):
       &:hover {
         cursor: pointer;


### PR DESCRIPTION
This PR fixes a small issue with IntelliSense not being displayed completely in the editor in the context of the Portal