### PR TITLE
1139. Scroll to active item in FeedPicker when key is used.

### DIFF
--- a/src/components/common/FeedPicker/FeedPicker.tsx
+++ b/src/components/common/FeedPicker/FeedPicker.tsx
@@ -230,6 +230,18 @@ const FeedPicker = React.forwardRef<HTMLDivElement, Props>(({ open, onClose, onS
     }
   };
 
+  const activeRef = React.useRef<HTMLInputElement>(null);
+  const activeId = activeTemplate?.id;
+
+  React.useEffect(() => {
+    if (activeId && activeRef.current) {
+      activeRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+    // eslint complains about including activeRef.current, but it works well to cause the scroll once the item
+    // has been identified.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeId, activeRef.current]);
+
   return (
     <StyledCard onKeyDown={(e: React.KeyboardEvent) => handleKeyDown(e)} ref={ref} tabIndex={-1}>
       <StyledTitle>{`New ${feedTypeName}`}</StyledTitle>
@@ -273,23 +285,22 @@ const FeedPicker = React.forwardRef<HTMLDivElement, Props>(({ open, onClose, onS
             <Box>
               {orderAlpha(filteredFeed)
                 .filter((feedEntry) => !feedEntry.private)
-                .map((feedEntry) => {
-                  return (
-                    <StyledColumnItem
-                      key={feedEntry.id}
-                      onClick={() => handleTemplateChange(feedEntry)}
-                      active={feedEntry.id === activeTemplate.id}
-                    >
-                      <StyledColumnItemImage
-                        src={urlOrSvgToImage(feedEntry.smallIcon)}
-                        alt={feedEntry.name}
-                        height="18"
-                        width="18"
-                      />
-                      {feedEntry.name}
-                    </StyledColumnItem>
-                  );
-                })}
+                .map((feedEntry) => (
+                  <StyledColumnItem
+                    key={feedEntry.id}
+                    onClick={() => handleTemplateChange(feedEntry)}
+                    active={feedEntry.id === activeTemplate.id}
+                    ref={feedEntry.id === activeTemplate.id ? activeRef : undefined}
+                  >
+                    <StyledColumnItemImage
+                      src={urlOrSvgToImage(feedEntry.smallIcon)}
+                      alt={feedEntry.name}
+                      height="18"
+                      width="18"
+                    />
+                    {feedEntry.name}
+                  </StyledColumnItem>
+                ))}
             </Box>
           )}
         </StyledColumn>

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -43,6 +43,10 @@ const useFeed = ({ isIntegration, onSubmit, onClose, open }: Props) => {
         setFeed(_feed);
         for (let i = 0; i < _feed.length; i++) {
           if (_feed[i].id === key) {
+            // When explicitly loading an entry, remove the private designation so that it shows up in the
+            // middle list.
+            delete _feed[i].private;
+            setRawActiveTemplate(_feed[i]);
             replaceMustache(data, _feed[i]).then((template) => setActiveTemplate(template));
             return;
           }


### PR DESCRIPTION
Also, allow entries marked 'private' to show up in the middle column when explicitly specified by key.