### PR TITLE
Enhancements to /make-go endpoint to support GSheets Add-On

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -64,6 +64,11 @@ export const routes: Array<RouteItem> = [
     component: MakeGoPage,
   },
   {
+    key: 'router-make-go',
+    path: '/make-go',
+    component: MakeGoPage,
+  },
+  {
     key: 'router-auth-callback',
     path: '/callback',
     component: AuthCallbackPage,

--- a/src/hooks/useAuthContext.ts
+++ b/src/hooks/useAuthContext.ts
@@ -47,17 +47,19 @@ const signIn = (silent?: boolean): void => {
   setSignInLocalStorageItems(window.location.pathname, requestedSearch);
   const urlSearchParams = new URLSearchParams(window.location.search);
   const requestedPath = (urlSearchParams.get('requestedPath') || window.location.pathname).replace(/ /g, '+');
+  const connection = urlSearchParams.get('fusebitConnection');
 
   const authLink = [
     REACT_APP_AUTH0_DOMAIN,
     '/authorize?response_type=token',
+    connection ? `&connection=${encodeURIComponent(connection)}` : '',
     `&client_id=${REACT_APP_AUTH0_CLIENT_ID}`,
     `&audience=${REACT_APP_FUSEBIT_DEPLOYMENT}`,
     `&redirect_uri=${window.location.origin}/callback?silentAuth=${silent ? 'true' : 'false'}`,
     `%26requestedPath=${requestedPath === '/callback' ? `/` : encodeURIComponent(requestedPath)}`,
     '&scope=openid profile email',
     `&screen_hint=${localStorage.getItem('screenHint')}`,
-    silent ? '&prompt=none' : '',
+    silent && !connection ? '&prompt=none' : '',
   ].join('');
 
   window.location.href = authLink;

--- a/src/hooks/useReplaceMustache.ts
+++ b/src/hooks/useReplaceMustache.ts
@@ -61,7 +61,18 @@ export const useReplaceMustache = () => {
             },
             feed: { ...JSON.parse(JSON.stringify(feed)) },
           },
+          query: {},
         };
+
+        const urlSearchParams = new URLSearchParams(window.location.search);
+        const fusebitParams = urlSearchParams.get('fusebitParams');
+        if (fusebitParams) {
+          try {
+            global.query = JSON.parse(fusebitParams);
+          } catch (e) {
+            // empty
+          }
+        }
 
         // No really good reason to delete this besides it making it difficult to console.log the globals.
         delete global.consts.feed.configuration;


### PR DESCRIPTION
1. Add support for specifying the connection name when authenticating users through Auth0 using the `?connection` query param, e.g. `?connection=google-oauth2` forces the use of Google Auth (which is what the Fusebit Add-On for GSheets will use). 
2. Add support to /make-go endpoint to create a new integration from a specific template. This is done using `?fusebitIntegrationTemaplate={template-id}` query param. 
3. Add support to /make-go endpoint to specify the integrationId of the integration to be created. This is done using `?fusebitIntegrationId={integration-id}` query param. 
4. Add support to /make-go endpoint to specify a property bag to be passed to the integration template for placeholder substitution purposes. This is done using `?fusebitParams={uri-encoded-json-object}` query param. This is used by the Fusebit Add-On for GSheets to specify an API key the add-on will use to authorize calls to the integration endpoints. 