### PR TITLE
Remove signup and login urls from organic

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /signup
+Disallow: /login


### PR DESCRIPTION
These are auth0 redirects and should not be showing up