### PR TITLE
Support for inviting team members

### DIFF
--- a/src/components/AccountTeam/InviteUserForm/InviteUser.tsx
+++ b/src/components/AccountTeam/InviteUserForm/InviteUser.tsx
@@ -1,0 +1,63 @@
+import CopyLine from '@components/common/CopyLine';
+import { Props } from '@interfaces/newUser';
+import { Button } from '@material-ui/core';
+import React, { useEffect } from 'react';
+import styled from 'styled-components';
+import * as CSC from '../../globalStyle';
+
+const StyledFormInputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 48px;
+  justify-content: center;
+`;
+
+const InviteUserForm = React.forwardRef<HTMLDivElement, Props>(({ onClose, createUser }, ref) => {
+  const [userCreating, setUserCreating] = React.useState(false);
+  const [token, setToken] = React.useState('');
+
+  useEffect(() => {
+    if (!userCreating) {
+      setUserCreating(true);
+      (async () => {
+        const _token = await createUser({
+          firstName: 'Invitation',
+          lastName: 'Pending',
+        });
+        setToken(_token);
+      })();
+    }
+  }, [userCreating, token, createUser]);
+
+  const invitationUrl = token ? `${window.location.protocol}//${window.location.host}/#init=${token}` : '';
+
+  return (
+    <div ref={ref}>
+      <>
+        <CSC.ModalTitle margin="48px 0">Invite New User</CSC.ModalTitle>
+        <CSC.ModalDescription>
+          Securely share the following invitation URL with the user. The invitation expires in eight hours.
+        </CSC.ModalDescription>
+        <div style={{ maxWidth: 800 }}>
+          <CopyLine text={invitationUrl}>{invitationUrl}</CopyLine>
+        </div>
+        <StyledFormInputWrapper>
+          <Button
+            onClick={() => onClose()}
+            style={{ width: '200px' }}
+            fullWidth={false}
+            size="large"
+            color="primary"
+            variant="contained"
+            disabled={!token}
+          >
+            {(!!token && 'Done') || 'Inviting...'}
+          </Button>
+        </StyledFormInputWrapper>
+      </>
+    </div>
+  );
+});
+
+export default InviteUserForm;

--- a/src/components/AccountTeam/InviteUserForm/index.ts
+++ b/src/components/AccountTeam/InviteUserForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from './InviteUser';

--- a/src/components/AccountTeam/InviteUserModal/InviteUserModal.tsx
+++ b/src/components/AccountTeam/InviteUserModal/InviteUserModal.tsx
@@ -1,0 +1,21 @@
+import { Backdrop } from '@material-ui/core';
+import Modal from '@components/common/Modal';
+import { useEntityApi } from '@hooks/useEntityApi';
+import InviteUserForm from '@components/AccountTeam/InviteUserForm';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const InviteUserModal = ({ onClose, open }: Props) => {
+  const { _createUser } = useEntityApi();
+
+  return (
+    <Modal disableActions open={open} onClose={onClose} closeAfterTransition BackdropComponent={Backdrop}>
+      <InviteUserForm createUser={_createUser} onClose={onClose} />
+    </Modal>
+  );
+};
+
+export default InviteUserModal;

--- a/src/components/AccountTeam/InviteUserModal/index.ts
+++ b/src/components/AccountTeam/InviteUserModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './InviteUserModal';

--- a/src/components/AccountTeam/UsersTable/UsersTable.tsx
+++ b/src/components/AccountTeam/UsersTable/UsersTable.tsx
@@ -10,12 +10,12 @@ import { useAuthContext } from '@hooks/useAuthContext';
 import { Account } from '@interfaces/account';
 import { useAccountUserGetAll } from '@hooks/api/v1/account/user/useGetAll';
 import DeleteUserModal from '../DeleteUserModal';
-import CreateUserModal from '../NewUserModal';
+import InviteUserModal from '../InviteUserModal';
 import NameColumn from './NameColumn';
 
 const UsersTable = () => {
   const { page, setPage, rowsPerPage, handleChangePage, handleChangeRowsPerPage } = usePagination();
-  const [newModalOpen, , toggleNewModal] = useModal();
+  const [inviteModalOpen, , toggleInviteModal] = useModal();
   const [deleteModalOpen, setDeleteModal, toggleDeleteModal] = useModal();
   const { getRedirectLink } = useGetRedirectLink();
   const history = useHistory();
@@ -44,14 +44,14 @@ const UsersTable = () => {
 
   const handleClickRow = (row: BaseTableRow) => history.push(getRedirectLink(`/authentication/${row.id}/overview`));
 
-  const handleNewIntegration = () => {
-    trackEventMemoized('New User Button Clicked', 'Users');
-    toggleNewModal();
+  const handleInviteUser = () => {
+    trackEventMemoized('Invite User Button Clicked', 'Users');
+    toggleInviteModal();
   };
 
   return (
     <>
-      <CreateUserModal onClose={toggleNewModal} open={newModalOpen} />
+      <InviteUserModal onClose={toggleInviteModal} open={inviteModalOpen} />
       <DeleteUserModal
         onConfirm={() => handleRowDelete('Account')}
         setOpen={setDeleteModal}
@@ -72,7 +72,8 @@ const UsersTable = () => {
           { id: 'userId', value: 'User-ID' },
         ]}
         loading={isLoading}
-        onClickNew={handleNewIntegration}
+        newButtonText="Invite user"
+        onClickNew={handleInviteUser}
         onDeleteAll={toggleDeleteModal}
         onSelectAll={handleSelectAllCheck}
         rows={rows}

--- a/src/components/common/BaseTable/BaseTable.tsx
+++ b/src/components/common/BaseTable/BaseTable.tsx
@@ -62,6 +62,7 @@ const BaseTable: React.FC<BaseTableProps> = ({
   headers,
   onDeleteAll,
   onClickNew,
+  newButtonText,
   entityName,
   onSelectRow,
   isSelected,
@@ -168,7 +169,7 @@ const BaseTable: React.FC<BaseTableProps> = ({
             </Button>
           ))}
           <Button onClick={onClickNew} startIcon={<AddIcon />} variant="outlined" color="primary" size="large">
-            New {entityName}
+            {newButtonText || `New ${entityName}`}
           </Button>
         </StyledButtonsContainer>
       )}

--- a/src/components/common/BaseTable/types.ts
+++ b/src/components/common/BaseTable/types.ts
@@ -19,6 +19,7 @@ export interface BaseTableProps {
     id: string;
     value: string;
   }[];
+  newButtonText?: string;
   entityName?: string;
   onSelectRow: (e: any, id: string) => void;
   isSelected: (id: string) => boolean;

--- a/src/hooks/useCreateToken.ts
+++ b/src/hooks/useCreateToken.ts
@@ -6,9 +6,16 @@ export const useCreateToken = () => {
   const { userData } = useAuthContext();
   const createToken = useAccountUserCreateToken<Operation>();
 
-  const _createToken = async (userId: string) => {
+  const _createToken = async (userId: string, protocol?: 'pki' | 'oauth') => {
     const response = await createToken.mutateAsync({
-      data: { protocol: 'pki', profile: { id: 'default', subscription: userData.subscriptionId } },
+      data: {
+        protocol: protocol || 'pki',
+        profile: {
+          id: 'default',
+          subscription: userData.subscriptionId,
+          oauth: {},
+        },
+      },
       userId,
       accountId: userData.accountId,
     });

--- a/src/hooks/useEntityApi.ts
+++ b/src/hooks/useEntityApi.ts
@@ -81,9 +81,15 @@ export const useEntityApi = (preventLoader?: boolean) => {
   const _createUser = async (data: Account) => {
     try {
       createLoader();
-      const response = await createUser.mutateAsync({ ...data, accountId: userData.accountId });
+      const response = await createUser.mutateAsync({
+        ...data,
+        accountId: userData.accountId,
+        access: {
+          allow: [{ action: '*', resource: `/account/${userData.accountId}/` }],
+        },
+      });
       if (response.data.id) {
-        const token = await _createToken(response.data.id);
+        const token = await _createToken(response.data.id, 'oauth');
         return token;
       }
     } catch (e) {

--- a/src/interfaces/auth0Token.ts
+++ b/src/interfaces/auth0Token.ts
@@ -5,8 +5,13 @@ export interface FusebitProfile {
   email?: string;
 }
 
+export interface FusebitProfileEx extends FusebitProfile {
+  accounts?: FusebitProfile[];
+  fusebitProvisionUrl?: string;
+}
+
 export interface Auth0Token {
   iss: string;
-  'https://fusebit.io/profile': FusebitProfile;
+  'https://fusebit.io/profile': FusebitProfileEx;
   'https://fusebit.io/new-user'?: boolean;
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -97,11 +97,15 @@ export const createAxiosClient: (token?: string, skipXUserAgent?: boolean) => Ax
   token,
   skipXUserAgent
 ) => {
-  const instance = axios.create({
-    headers: {
-      authorization: `Bearer ${token}`,
-    },
-  });
+  const instance = axios.create(
+    token
+      ? {
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        }
+      : {}
+  );
 
   if (!skipXUserAgent) {
     instance.defaults.headers['X-User-Agent'] = X_USER_AGENT;


### PR DESCRIPTION
This adds support for inviting team members to an account: 

1. The "New user" button on the Teams page is replaced with "Invite user". 
2. It generates an "invite link" that needs to be shared securely with the person being invited. 
3. When the invitee clicks the link, they are asked to log in, and then their identity is associated with the user that was created for them at the time the invite link was generated. 

This should be safe to deploy to stage-manage.fusebit.io. Before it can be deployed to prod, changes in the provisioning function must be deployed. 

On the backend of this, we allow a single user to be added to multiple Fusebit accounts and maintain that association. We want to add support to select the account they want to work with to the portal (discussion coming soon). In this PR, the portal always logs people into the last account they accepted an invitation to. 

![image](https://user-images.githubusercontent.com/822369/167797425-793be1ab-f6d3-4706-8cd5-f3e233cc561e.png)
